### PR TITLE
Add rollup, npm module-ize

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,20 +1,24 @@
 {
-  "name": "mparticle-adobe",
-  "version": "1.0.0",
+  "name": "integration-adobe-client",
+  "version": "2.0.0",
   "description": "mParticle Adobe kit integration",
+  "browser": "dist/AdobeClientSideKit.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/mparticle-integrations/mparticle-javascript-integration-adobe.git"
   },
   "scripts": {
-      "buildClient": "cat src/Adobe-SDKs/VisitorAPI.js src/Adobe-SDKs/AppMeasurement.js src/AdobeKit-dev.js > AdobeKit.js",
-      "buildServer": "cat src/Adobe-SDKs/VisitorAPI.js src/AdobeServerSideKit-dev.js > AdobeServerSideKit.js"
+    "buildClient": "rollup --config rollup.client.config.js; cat src/Adobe-SDKs/VisitorAPI.js src/Adobe-SDKs/AppMeasurement.js src/AdobeClientSideKit-temp.js > AdobeKit.js; cp AdobeKit.js dist/AdobeClientSideKit.js; rm src/AdobeClientSideKit-temp.js",
+    "buildServer": "rollup --config rollup.server.config.js; cat src/Adobe-SDKs/VisitorAPI.js src/AdobeServerSideKit-temp.js > AdobeServerSideKit.js; cp AdobeServerSideKit.js dist/AdobeServerSideKit.js; rm src/AdobeServerSideKit-temp.js"
   },
   "author": "Robert Ing (ring@mparticle.com)",
   "license": "Apache",
   "devDependencies": {
     "blanket": "^1.1.7",
     "should": "^7.1.0",
-    "mocha": "^2.3.2"
+    "mocha": "^2.3.2",
+    "rollup": "^1.13.1",
+    "rollup-plugin-commonjs": "^10.0.0",
+    "rollup-plugin-node-resolve": "^5.0.1"
   }
 }

--- a/rollup.client.config.js
+++ b/rollup.client.config.js
@@ -1,0 +1,20 @@
+import resolve from 'rollup-plugin-node-resolve';
+import commonjs from 'rollup-plugin-commonjs';
+
+export default [{
+    input: 'src/AdobeClientSideKit-dev.js',
+    output: {
+        file: 'src/AdobeClientSideKit-temp.js',
+        format: 'umd',
+        exports: 'named',
+        name: 'mp-adobe-kit',
+        strict: false
+    },
+    plugins: [
+        resolve({
+            browser: true
+        }),
+        commonjs()
+    ]
+}
+] 

--- a/rollup.server.config.js
+++ b/rollup.server.config.js
@@ -1,0 +1,20 @@
+import resolve from 'rollup-plugin-node-resolve';
+import commonjs from 'rollup-plugin-commonjs';
+
+export default [{
+    input: 'src/AdobeServerSideKit-dev.js',
+    output: {
+        file: 'src/AdobeServerSideKit-temp.js',
+        format: 'umd',
+        exports: 'named',
+        name: 'mp-adobe-kit',
+        strict: false
+    },
+    plugins: [
+        resolve({
+            browser: true
+        }),
+        commonjs()
+    ]
+}
+] 

--- a/src/AdobeClientSideKit-dev.js
+++ b/src/AdobeClientSideKit-dev.js
@@ -20,6 +20,7 @@
 (function (window) {
     var name = 'Adobe',
         ADOBEMODULENUMBER = 124,
+        moduleId = ADOBEMODULENUMBER,
         MARKETINGCLOUDIDKEY = 'mid',
         MessageType = {
             SessionStart: 1,
@@ -467,12 +468,29 @@
         this.process = processEvent;
     };
 
+    function getId() {
+        return moduleId;
+    }
+
+    function register(config) {
+        if (config.kits) {
+            config.kits[name] = {
+                constructor: constructor
+            };
+        }
+    }
+
     if (!window || !window.mParticle || !window.mParticle.addForwarder) {
         return;
     }
 
     window.mParticle.addForwarder({
         name: name,
-        constructor: constructor
+        constructor: constructor,
+        getId: getId
     });
+
+    module.exports = {
+        register: register
+    };
 })(window);

--- a/test/index-server-side-tests.html
+++ b/test/index-server-side-tests.html
@@ -13,8 +13,8 @@
 
     <script>mocha.setup('bdd')</script>
 
+    <script src="../AdobeServerSideKit.js"></script>
     <script src="server-side-tests.js"></script>
-    <script src="../src/AdobeServerSideKit-dev.js"></script>
     <script>
         mocha.run();
     </script>

--- a/test/index.html
+++ b/test/index.html
@@ -13,8 +13,8 @@
 
     <script>mocha.setup('bdd')</script>
 
+    <script src="../AdobeKit.js"></script>
     <script src="tests.js"></script>
-    <script src="../src/AdobeKit-dev.js"></script>
     <script>
         mocha.run();
     </script>


### PR DESCRIPTION
Putting this PR here, but some thoughts:
* i think that adobe client and adobe server side should be their own packages, so perhaps this needs to be split into 2? although next comment might complicate/inform things
* i believe brian did something fancy with the DB and the server side piece to all this.  do we need to think through how that plays into this with the config that's returned?  i don't believe so but i wanted to bring that up