### PR TITLE
fix: Reset contextData after events logged to prevent data leaks in between events

### DIFF
--- a/packages/AdobeClient/src/AdobeClientSideKit.js
+++ b/packages/AdobeClient/src/AdobeClientSideKit.js
@@ -130,7 +130,6 @@ var constructor = function() {
 
             // On first load, adobe will call the callback correctly if no MCID exists
             // On subsequent loads, it does not, so we need to manually call setMCIDOnIntegrationAttributes
-            debugger;
             var mcID = Visitor.getInstance(
                 settings.organizationID,
                 visitorOptions

--- a/packages/AdobeClient/src/AdobeClientSideKit.js
+++ b/packages/AdobeClient/src/AdobeClientSideKit.js
@@ -130,6 +130,7 @@ var constructor = function() {
 
             // On first load, adobe will call the callback correctly if no MCID exists
             // On subsequent loads, it does not, so we need to manually call setMCIDOnIntegrationAttributes
+            debugger;
             var mcID = Visitor.getInstance(
                 settings.organizationID,
                 visitorOptions
@@ -201,8 +202,11 @@ var constructor = function() {
         return null;
     }
 
-    // for each type of event, we run setMappings which sets the eVars, props, hvars, and contextData values
     // after each event is sent to the server (either using t() for pageViews or tl() for non-pageview events), clearVars() is run to wipe out
+    function resetVariables() {
+        appMeasurement.clearVars();
+        appMeasurement.contextData = {};
+    }
     // any eVars, props, and hvars
     function processEvent(event) {
         var linkName,
@@ -327,7 +331,7 @@ var constructor = function() {
         appMeasurement.linkTrackVars = linkTrackVars;
         appMeasurement.tl(true, 'o', linkName);
 
-        appMeasurement.clearVars();
+        resetVariables();
 
         return true;
     }
@@ -463,10 +467,10 @@ var constructor = function() {
             appMeasurement.pageName =
                 pageName || event.EventName || window.document.title;
             appMeasurement.t();
-            appMeasurement.clearVars();
+            resetVariables();
             return true;
         } catch (e) {
-            appMeasurement.clearVars();
+            resetVariables();
             return { error: 'logPageView not called, error ' + e };
         }
     }
@@ -495,16 +499,17 @@ var constructor = function() {
                 appMeasurement.linkTrackVars = linkTrackVars;
 
                 appMeasurement.tl(true, 'o', linkName);
-                appMeasurement.clearVars();
+                resetVariables();
                 return true;
             } else {
-                appMeasurement.clearVars();
+                resetVariables();
                 window.console.log(
                     'event name not mapped, aborting event logging'
                 );
+                return false;
             }
         } catch (e) {
-            appMeasurement.clearVars();
+            resetVariables();
             return { error: e };
         }
     }

--- a/packages/AdobeClient/src/AdobeClientSideKit.js
+++ b/packages/AdobeClient/src/AdobeClientSideKit.js
@@ -201,6 +201,7 @@ var constructor = function() {
         return null;
     }
 
+    // for each type of event, we run setMappings which sets the eVars, props, hvars, and contextData values
     // after each event is sent to the server (either using t() for pageViews or tl() for non-pageview events), clearVars() is run to wipe out
     function resetVariables() {
         appMeasurement.clearVars();

--- a/test/test.js
+++ b/test/test.js
@@ -276,7 +276,6 @@ describe('AdobeEventForwarder Forwarder', function () {
 
     test('should log page view', function(done) {
         var appMeasurementInstance = s_gi('testReportSuiteId');
-
         var contextDataMock = {};
         // have to add a setter because appMeasurement.contextData is set to {} after each event is logged now, which removes it from appMeasurement
         Object.defineProperty(

--- a/test/test.js
+++ b/test/test.js
@@ -275,14 +275,27 @@ describe('AdobeEventForwarder Forwarder', function () {
     });
 
     test('should log page view', function(done) {
+        var appMeasurementInstance = s_gi('testReportSuiteId');
+
+        var contextDataMock = {};
+        // have to add a setter because appMeasurement.contextData is set to {} after each event is logged now, which removes it from appMeasurement
+        Object.defineProperty(
+            appMeasurementInstance.contextData,
+            'contextTestValue',
+            {
+                set: function(name) {
+                    contextDataMock['contextTestValue'] = name;
+                }
+            }
+        );
         mParticle.logPageView('log page view test', {color: 'green', gender: 'female', c1: 'c1testValue', linkName: 'test'});
 
-        var appMeasurementInstance = s_gi('testReportSuiteId');
         expect(appMeasurementInstance.pageName).toBe('log page view test');
         expect(appMeasurementInstance.eVar1).toBe('green');
         expect(appMeasurementInstance.prop2).toBe('female');
         expect(appMeasurementInstance.hier1).toBe('test');
-        expect(appMeasurementInstance.contextData.contextTestValue).toBe('c1testValue');
+        expect(contextDataMock.contextTestValue).toBe('c1testValue');
+        expect(appMeasurementInstance.contextData).toStrictEqual({});
         expect(appMeasurementInstance.tCalled).toBe(true);
         expect(appMeasurementInstance.tlCalled).toBe(false);
         expect(appMeasurementInstance.clearVarsCalled).toBe(true);
@@ -302,17 +315,25 @@ describe('AdobeEventForwarder Forwarder', function () {
     });
 
     test('should log an event when trying to log a mapped page view value', function(done) {
+        var appMeasurementInstance = s_gi('testReportSuiteId');
+        var contextDataMock = {};
+        // have to add a setter because appMeasurement.contextData is set to {} after each event is logged now, which removes it from appMeasurement
+        Object.defineProperty(appMeasurementInstance.contextData, 'contextTestValue', {
+            set: function(name) {
+                contextDataMock['contextTestValue'] = name;
+            }
+        });
+
         configureAdobeForwarderAndReInit('notallowed', 'True', 'True');
         window.document.title = 'test';
         mParticle.logPageView('Find Ticket', {color: 'green', gender: 'female', c1: 'c1testValue', linkName: 'test'});
-
-        var appMeasurementInstance = s_gi('testReportSuiteId');
         expect(appMeasurementInstance.pageName).toBe(window.document.title);
         expect(appMeasurementInstance.events).toBe('event1');
         expect(appMeasurementInstance.eVar1).toBe('green');
         expect(appMeasurementInstance.prop2).toBe('female');
         expect(appMeasurementInstance.hier1).toBe('test');
-        expect(appMeasurementInstance.contextData.contextTestValue).toBe('c1testValue');
+        expect(contextDataMock.contextTestValue).toBe('c1testValue');
+        expect(appMeasurementInstance.contextData).toStrictEqual({});
         expect(appMeasurementInstance.tlCalled).toBe(true);
         expect(appMeasurementInstance.tCalled).toBe(false);
         expect(appMeasurementInstance.clearVarsCalled).toBe(true);
@@ -532,7 +553,7 @@ describe('AdobeEventForwarder Forwarder', function () {
         var ta = mParticle.eCommerce.createTransactionAttributes('tID123', 'aff1', 'coupon', 456, 10, 5);
 
         // in a jest testing environment, there is not title, so we will set one
-        window.document.title = 'test'
+        window.document.title = 'test';
         mParticle.eCommerce.logPurchase(ta, [product1, product2], true, {gender: 'male', color: 'blue', discount: 20});
 
         var appMeasurementInstance = s_gi('testReportSuiteId');


### PR DESCRIPTION
The previous code was written with the false impression that `appMeasurement.clearVars()` cleared _**everything**_ on the appMeasurement object. However, according to their [docs](https://experienceleague.adobe.com/docs/analytics/implementation/vars/functions/clearvars.html?lang=en), it does not clear context data. 

This PR refactors code so that `clearVars` is called and also sets `appMeasurement.contextData` to `{}` after every successful and failed event log to prevent data leakage between events.