### PR TITLE
fix: Add suffix of `server` to server side forwarder

### DIFF
--- a/packages/AdobeServer/src/AdobeServerSideKit.js
+++ b/packages/AdobeServer/src/AdobeServerSideKit.js
@@ -24,12 +24,14 @@ var MessageType = {
 };
 var name = 'Adobe',
     MARKETINGCLOUDIDKEY = 'mid',
-    ADOBEMODULENUMBER = 124;
+    ADOBEMODULENUMBER = 124,
+    suffix = 'Server';
 
 var constructor = function() {
     var self = this,
         isAdobeServerKitInitialized;
     self.name = name;
+    self.suffix = suffix;
     self.adobeMediaSDK = new AdobeHbkConstructor();
 
     function initForwarder(forwarderSettings, service, testMode) {
@@ -100,15 +102,18 @@ function getId() {
 if (window && window.mParticle && window.mParticle.addForwarder) {
     window.mParticle.addForwarder({
         name: name,
+        suffix: suffix,
         constructor: constructor,
         getId: getId
     });
 }
 
 function register(config) {
+    var forwarderNameWithSuffix = [name, suffix].join('-');
     if (!config) {
         window.console.log(
-            'You must pass a config object to register the kit ' + name
+            'You must pass a config object to register the kit ' +
+                forwarderNameWithSuffix
         );
         return;
     }
@@ -121,17 +126,19 @@ function register(config) {
     }
 
     if (isObject(config.kits)) {
-        config.kits[name] = {
+        config.kits[forwarderNameWithSuffix] = {
             constructor: constructor
         };
     } else {
         config.kits = {};
-        config.kits[name] = {
+        config.kits[forwarderNameWithSuffix] = {
             constructor: constructor
         };
     }
     window.console.log(
-        'Successfully registered ' + name + ' to your mParticle configuration'
+        'Successfully registered ' +
+            forwarderNameWithSuffix +
+            ' to your mParticle configuration'
     );
 }
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -20,7 +20,7 @@ const builds = {
     server_iife: {
         output: {
             ...outputOptions,
-            name: 'mParticleAdobe',
+            name: 'mParticleAdobeServer',
             file: 'packages/AdobeServer/dist/AdobeServerSideKit.iife.js',
             format: 'iife'
         }
@@ -29,7 +29,7 @@ const builds = {
     server_cjs: {
         output: {
             ...outputOptions,
-            name: 'mParticleAdobe',
+            name: 'mParticleAdobeServer',
             file: 'packages/AdobeServer/dist/AdobeServerSideKit.common.js',
             format: 'cjs'
         }
@@ -38,7 +38,7 @@ const builds = {
     client_iife: {
         output: {
             ...outputOptions,
-            name: 'mParticleAdobe',
+            name: 'mParticleAdobeClient',
             file: 'packages/AdobeClient/dist/AdobeClientSideKit.iife.js',
             format: 'iife'
         }
@@ -47,7 +47,7 @@ const builds = {
     client_cjs: {
         output: {
             ...outputOptions,
-            name: 'mParticleAdobe',
+            name: 'mParticleAdobeClient',
             file: 'packages/AdobeClient/dist/AdobeClientSideKit.common.js',
             format: 'cjs'
         }

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,4 +1,16 @@
 /* eslint-disable no-undef*/
+
+// If we are testing this in a node environemnt, we load the common.js Braze kit
+
+var AdobeServerSideInstance;
+if (typeof require !== 'undefined') {
+    AdobeServerSideInstance = require('../packages/AdobeServer/dist/AdobeServerSideKit.common');
+} else {
+    // we don't currently have an index.html file, but if we ever had one, this would pass
+    AdobeServerSideInstance = window.mParticleAdobe;
+}
+
+
 describe('AdobeServerSide Forwarder', function() {
     window.mParticle.isTestEnvironment = true;
 
@@ -39,6 +51,7 @@ describe('AdobeServerSide Forwarder', function() {
 
     beforeEach(function() {
         window.AppMeasurement = MockAppMeasurement;
+        window.mock = new MockVisitorInstance();
         window.Visitor = Visitor;
         window.ADB = {
             va: {
@@ -82,6 +95,24 @@ describe('AdobeServerSide Forwarder', function() {
         expect(mParticle._getIntegrationDelays()[124]).toBe(false);
 
         done();
+    });
+
+    it('should have a property of suffix', function() {
+        expect(window.mParticle.forwarder).toHaveProperty('suffix', 'Server');
+    });
+
+    it('should register a forwarder with version number onto a config', function() {
+        var config = {};
+        AdobeServerSideInstance.register(config);
+        expect(config).toHaveProperty('kits');
+        expect(config.kits).toHaveProperty('Adobe-Server');
+    });
+
+    it('should register a forwarder with version number onto a config with a kits key', function() {
+        var config = {kits: {}};
+        AdobeServerSideInstance.register(config);
+        expect(config).toHaveProperty('kits');
+        expect(config.kits).toHaveProperty('Adobe-Server');
     });
 
     test('should initialize with a custom audience manager server if provided', function(done) {


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
In order to support allowing multiple versions of our client side kit to be served, we add support for a suffix config item. This is for V3.

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/REPLACEME
